### PR TITLE
Adding print_lines_not_matched option & layering of config

### DIFF
--- a/ctail
+++ b/ctail
@@ -12,18 +12,14 @@
 # does not support associative arrays.                                        #
 ###############################################################################
 
-TAIL=`which tail`
-AWK=`which awk`
-if [[ -z $TAIL ]]; then
+if ! TAIL=$(which tail); then
     echo -e "Cannot find tail executable.\n"
     exit 1
 fi
-if [[ -z $AWK ]]; then
+if ! AWK=$(which awk); then
     echo -e "Cannot find awk executable.\n"
     exit 1
 fi
-
-CWD=`dirname $0`
 
 declare -A log
 log["INFO"]="BWhite"
@@ -31,8 +27,23 @@ log["ERROR"]="BRed"
 log["WARN"]="BYellow"
 log["DEBUG"]="BGreen"
 
+# keep original behaviour; hide lines that does not match any of the pattern
+: ${print_lines_not_matched:=0}
+
+# keeping the original behaviour; load config from the ctail script's directory
+CWD=`dirname $0`
 if [[ -f "$CWD/ctail.config" ]]; then
     source "$CWD/ctail.config"
+fi
+
+# if there is a config in $HOME, load that
+if [[ -f "$HOME/ctail.config" ]]; then
+    source "$HOME/ctail.config"
+fi
+
+# if there is a config in current directory, load that too
+if [[ -f "./ctail.config" ]]; then
+    source "./ctail.config"
 fi
 
 declare -A colours
@@ -73,9 +84,16 @@ colours["BIPurple"]="\033[1;95m"
 colours["BICyan"]="\033[1;96m"
 colours["BIWhite"]="\033[1;97m"
 
-AWK_EXPRESSION=""
-for i in "${!log[@]}"; do
-    AWK_EXPRESSION="/$i/ {print \"${colours[${log[$i]}]}\" \$0 \"\033[39m\"} $AWK_EXPRESSION"
-done
+awk_script()
+{
+	for i in "${!log[@]}"; do
+		echo "/$i/ {print \"${colours[${log[$i]}]}\" \$0 \"\033[39m\"; next;}"
+	done
 
-$TAIL "$@" | $AWK "$AWK_EXPRESSION"
+	if [[ "$print_lines_not_matched" == "1" ]]; then
+        # let us not miss anything that did not match any of the above colourisation rules
+        echo '{print $0}'
+    fi
+}
+
+$AWK -f <(awk_script) <($TAIL "$@")


### PR DESCRIPTION
Please review my changes, described below.

The option `print_lines_not_matched` can be added into the config file; by default it is set to `0`, keeping the original behaviour.

Also added a few more locations from which the config file is loaded. The default behaviour is kept; this change only adds more locations.
This allows for layering of config patterns; Useful for projects, where they can have their own config (for example); not the global one

I have also tweaked the `awk + tail` invocation line to be more easily extendible; what ever the function `awk_script` prints is passed into `awk` as script.
