### PR TITLE
add config example for rsyslog

### DIFF
--- a/examples/rsyslog/README.md
+++ b/examples/rsyslog/README.md
@@ -1,0 +1,13 @@
+# rsyslog example
+
+The rsyslog config file [add-priority-text.conf](add-priority-text.conf) has the necessary config to add 
+syslog-priority-text to the logline produced by rsyslog. The important part of the config is
+`[%syslogpriority-text%]`.
+
+You can copy the config file to /etc/rsyslog.d/03-add-priority-text.conf and restart `rsyslog` service.
+
+Now you need to copy the [ctail config](ctail.config) to your home directory.
+
+That's it! Now you should be able to colourise logs using the command
+
+    ctail -f /var/log/messages

--- a/examples/rsyslog/add-priority-text.conf
+++ b/examples/rsyslog/add-priority-text.conf
@@ -1,0 +1,3 @@
+$template FormatWithPriority,"%timereported% %HOSTNAME% %syslogtag% [%syslogpriority-text%]%msg:::drop-last-lf%\n"
+$ActionFileDefaultTemplate FormatWithPriority
+

--- a/examples/rsyslog/ctail.config
+++ b/examples/rsyslog/ctail.config
@@ -1,0 +1,17 @@
+# Available colours:
+#   Black, Red, Green, Yellow, Blue, Purple, Cyan, White
+# Modifiers:
+#   bold                    - B (e.g. BBlack)
+#   high intensity          - I (e.g. IBlack)
+#   bold hight intensity    - BI (e.g. BIBlack)
+
+unset log
+declare -A log
+log['\[crit\]']='IRed'
+log['\[err\]']='Red'
+log['\[warning\]']='Yellow'
+log['\[notice\]']='White'
+log['\[info\]']='Cyan'
+log['\[debug\]']='IBlack'
+
+print_lines_not_matched=1


### PR DESCRIPTION
Those souls who use rsyslog as their syslog service can benefit from `ctail` using the example config.